### PR TITLE
docs(project): add security policy for project

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## 1. Supported Versions
+
+This project is currently under active development and has no stable version.
+There several reasons, why it has not reached a stable version yet.
+
+1. active in development (`<1.0.0`)
+2. depedencies not stable
+
+## 2. Reporting a Vulnerability
+
+The project is under active development and not stable yet. If you have discovered a security vulnerability, 
+we greatly appreciate your cooperation in disclosing it to me in a responsible manner.
+
+Please follow these steps:
+
+You can report security vulnerabilities through public GitHub issues.
+Provide me as much information as possible about the vulnerability, including:
+
+- The version affected
+- A detailed description of the vulnerability
+- Steps to reproduce the vulnerability or proof of concept
+- Any potential impacts of the vulnerability
+
+What to expect after you report a vulnerability:
+
+I will assess the vulnerability and may contact you for further information.
+Once the vulnerability is evaluated, I will send you an update about the status and my plans for mitigation.
+I aim to fix confirmed vulnerabilities as quickly as possible and will release a security update for the affected versions.
+After the fix is released, I will publish a security advisory on GitHub detailing the vulnerability and its fix.
+
+
+## 3. Security Updates
+
+This section is for notifying about how and when users can expect to receive security updates for the vulnerabilities that have been fixed.
+
+Security advisories will be published under the Security tab of our GitHub repository.
+Users are encouraged to update to the latest patched versions as soon as possible.
+
+## 4. Recognition
+
+Contributors who responsibly disclose security vulnerabilities will be publicly acknowledged (if they choose). 
+If you would like to be credited, please include a preferred name and link in your report.


### PR DESCRIPTION
I've included instructions for reporting a security vulnerability in your project by adding a security policy.

Closes #19 